### PR TITLE
Fix Firefox test execution by adding correct capabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <compiler.version>1.8</compiler.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <selenium.version>4.18.1</selenium.version>
+        <selenium.version>4.32.0</selenium.version>
         <properties.version>2.0.RC6</properties.version>
         <allure.version>2.24.0</allure.version>
         <junit.version>4.13.2</junit.version>

--- a/src/test/java/com/aerokube/selenoid/misc/WebDriverRule.java
+++ b/src/test/java/com/aerokube/selenoid/misc/WebDriverRule.java
@@ -5,6 +5,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -24,6 +25,7 @@ public class WebDriverRule implements TestRule {
 
     private static final TestProperties PROPERTIES = PropertyLoader.newInstance().populate(TestProperties.class);
     private static final String CHROME = "chrome";
+    private static final String FIREFOX = "firefox";
     private static final String YANDEX = "yandex";
     private static final String OPERA = "opera";
 
@@ -77,6 +79,10 @@ public class WebDriverRule implements TestRule {
                 yandexOptions.addArguments("no-sandbox");
                 yandexOptions.setCapability("selenoid:options", selenoidOptions);
                 return yandexOptions;
+            case FIREFOX:
+                FirefoxOptions firefoxOptions = new FirefoxOptions();
+                firefoxOptions.setCapability("selenoid:options", selenoidOptions);
+                return firefoxOptions;
             default:
                 DesiredCapabilities caps = new DesiredCapabilities(PROPERTIES.getBrowserName(), PROPERTIES.getBrowserVersion(), Platform.LINUX);
                 caps.setCapability("selenoid:options", selenoidOptions);


### PR DESCRIPTION
Firefox beta and nightly tests could not be launched due to incorrect capabilities. This PR fixes the capabilities by adding FirefoxOptions and bumping the Selenium version to latest.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
